### PR TITLE
Fix home page conflict and sticky footer

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,15 +23,15 @@
     <%= javascript_importmap_tags %>
   </head>
 
-  <body>
+  <body class="d-flex flex-column min-vh-100">
 
-  <div class="container">
+  <div class="container flex-grow-1">
     <p class="notice"><%= notice %></p>
     <p class="alert"><%= alert %></p>
 
     <%= yield %>
-    <%= render "shared/footer" %>
   </div>
+  <%= render "shared/footer" %>
 
 </body>
 </html>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -6,19 +6,6 @@
   <h1 class="home-title mb-2">Tu as du temps ?</h1>
   <p class="home-tagline mb-0">On a le plan.</p>
 
-<<<<<<< HEAD
-      <p class="mb-5 opacity-75">
-        Tu as du temps ? On a le plan !
-      </p>
-
-      <div class="d-grid gap-3">
-        <%= button_to "Start a chat", chats_path,
-            class: "btn button-home-custom fw-semibold" %>
-      </div>
-    </div>
-  </div>
-=======
   <%= button_to "Commence ton aventure", chats_path,
       class: "btn home-cta mt-5" %>
->>>>>>> 927f67af082ed8bced932a46cc1df5c2f19a0471
 </div>


### PR DESCRIPTION
## Summary
- Resolve unresolved merge conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) in `home.html.erb`
- Make footer sticky at the bottom of the page using flexbox (`d-flex flex-column min-vh-100` on body, `flex-grow-1` on container)
- Move footer rendering outside the main container so it spans the full width at the bottom

## Test plan
- [ ] Verify home page renders without any conflict markers
- [ ] Verify footer sticks to the bottom on pages with little content
- [ ] Verify footer behaves normally on pages with lots of content

🤖 Generated with [Claude Code](https://claude.com/claude-code)